### PR TITLE
Count exposed services and store them in the VanRouterInspectResponse

### DIFF
--- a/api/types/client.go
+++ b/api/types/client.go
@@ -28,8 +28,9 @@ type VanServiceInterfaceCreateOptions struct {
 
 type VanRouterInspectResponse struct {
 	Status            VanRouterStatusSpec
-	QdrVersion        string
+	TransportVersion  string
 	ControllerVersion string
+        ExposedServices   int
 }
 
 type VanConnectorInspectResponse struct {

--- a/client/van_router_inspect.go
+++ b/client/van_router_inspect.go
@@ -30,8 +30,14 @@ func (cli *VanClient) VanRouterInspect(ctx context.Context) (*types.VanRouterIns
 			vir.Status.ConnectedSites = connected
 		}
 
-		vir.QdrVersion = kube.GetComponentVersion(cli.Namespace, cli.KubeClient, types.TransportContainerName)
+		vir.TransportVersion = kube.GetComponentVersion(cli.Namespace, cli.KubeClient, types.TransportContainerName)
 		vir.ControllerVersion = kube.GetComponentVersion(cli.Namespace, cli.KubeClient, types.ControllerContainerName)
+                vsis, err := cli.VanServiceInterfaceList(context.Background())
+                if err != nil {
+                  vir.ExposedServices = 0
+                } else {
+                  vir.ExposedServices = len(vsis)
+                }
 	}
 	return vir, err
 

--- a/cmd/skupper/skupper.go
+++ b/cmd/skupper/skupper.go
@@ -230,6 +230,13 @@ func main() {
 						fmt.Printf(" It is connected to %d other sites (%d indirectly).", vir.Status.ConnectedSites.Total, vir.Status.ConnectedSites.Indirect)
 					}
 				}
+                                if vir.ExposedServices == 0 {
+                                        fmt.Printf(" It has no exposed services.")
+                                } else if vir.ExposedServices == 1 {
+                                        fmt.Printf(" It has 1 exposed service.")
+                                } else {
+                                        fmt.Printf(" It has %d exposed services.", vir.ExposedServices)
+                                }
 				fmt.Println()
 			} else {
 				fmt.Println("Unable to retrieve skupper status: ", err.Error())
@@ -324,7 +331,7 @@ func main() {
 			vir, err := cli.VanRouterInspect(context.Background())
 			if err == nil {
 				fmt.Printf("skupctl version              %s\n", version)
-				fmt.Printf("qdr version                  %s\n", vir.QdrVersion)
+				fmt.Printf("transport version            %s\n", vir.TransportVersion)
 				fmt.Printf("controller version           %s\n", vir.ControllerVersion)
 			} else {
 				fmt.Println("Unable to retrieve skupper component versions: ", err.Error())


### PR DESCRIPTION
Count exposed services and store them in the VanRouterInspectResponse
struct.  Also in that struct, change QdrVersion to TransportVersion.
