### PR TITLE
Change all error print statements to error returns, using fmt.Errorf

### DIFF
--- a/client/van_router_create.go
+++ b/client/van_router_create.go
@@ -444,7 +444,10 @@ func (cli *VanClient) VanRouterCreate(ctx context.Context, options types.VanRout
 
 	van := GetVanRouterSpecFromOpts(options, cli, lbip)
 
-	dep := kube.NewTransportDeployment(van, cli.KubeClient)
+	dep, err := kube.NewTransportDeployment(van, cli.KubeClient)
+        if err != nil {
+                return err
+        }
 	ownerRef := kube.GetOwnerReference(dep)
 
 	for _, sa := range van.Transport.ServiceAccounts {
@@ -520,7 +523,10 @@ func (cli *VanClient) VanRouterCreate(ctx context.Context, options types.VanRout
 
 	if options.EnableController {
 		GetVanControllerSpec(options, van, dep)
-		depController := kube.NewControllerDeployment(van, ownerRef, cli.KubeClient)
+		depController, err := kube.NewControllerDeployment(van, ownerRef, cli.KubeClient)
+                if err != nil {
+                        return err
+                }
 		ownerRef = kube.GetOwnerReference(depController)
 		for _, sa := range van.Controller.ServiceAccounts {
 			kube.NewServiceAccountWithOwner(sa, ownerRef, van.Namespace, cli.KubeClient)

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -229,21 +229,17 @@ func PutCertificateData(name string, secretFile string, certData CertificateData
 	}
 }
 
-func GetSecretContent(secretFile string) map[string][]byte {
+func GetSecretContent(secretFile string) (map[string][]byte, error) {
 	yaml, err := ioutil.ReadFile(secretFile)
 	if err != nil {
-		fmt.Printf("Could not read connection token: %s", err)
-		fmt.Println()
-		return nil
+		return nil, fmt.Errorf("Could not read connection token: %w", err)
 	}
 	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme,
 		scheme.Scheme)
 	var secret corev1.Secret
 	_, _, err = s.Decode(yaml, nil, &secret)
 	if err != nil {
-		fmt.Printf("Could not parse connection token: %s", err)
-		fmt.Println()
-		return nil
+		return nil, fmt.Errorf("Could not parse connection token: %w", err)
 	}
 	content := make(map[string][]byte)
 	for k, v := range secret.Data {
@@ -252,5 +248,5 @@ func GetSecretContent(secretFile string) map[string][]byte {
 	for k, v := range secret.ObjectMeta.Annotations {
 		content[k] = []byte(v)
 	}
-	return content
+	return content, nil
 }

--- a/pkg/kube/configmaps.go
+++ b/pkg/kube/configmaps.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ajssmith/skupper/api/types"
 )
 
-func NewConfigMapWithOwner(name string, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) *corev1.ConfigMap {
+func NewConfigMapWithOwner(name string, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) (*corev1.ConfigMap, error) {
 
 	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -29,14 +28,10 @@ func NewConfigMapWithOwner(name string, owner metav1.OwnerReference, namespace s
 	actual, err := kubeclient.CoreV1().ConfigMaps(namespace).Create(configMap)
 
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			fmt.Println("ConfigMap", name, "already exists")
-		} else {
-			fmt.Println("Could not create ConfigMap", name, ":", err)
-		}
+                return nil, fmt.Errorf("Could not create ConfigMap %s: %w", name, err)
 	}
 
-	return actual
+	return actual, nil
 }
 
 func GetConfigMap(name string, namespace string, cli *kubernetes.Clientset) (*corev1.ConfigMap, error) {

--- a/pkg/kube/deployments.go
+++ b/pkg/kube/deployments.go
@@ -258,12 +258,11 @@ func NewProxyDeployment(serviceInterface types.ServiceInterface, namespace strin
 
 }
 
-func NewControllerDeployment(van *types.VanRouterSpec, ownerRef metav1.OwnerReference, cli *kubernetes.Clientset) *appsv1.Deployment {
+func NewControllerDeployment(van *types.VanRouterSpec, ownerRef metav1.OwnerReference, cli *kubernetes.Clientset) (*appsv1.Deployment, error) {
 	deployments := cli.AppsV1().Deployments(van.Namespace)
 	existing, err := deployments.Get(types.ControllerDeploymentName, metav1.GetOptions{})
 	if err == nil {
-		fmt.Println("VAN site controller already exists")
-		return existing
+		return existing, nil
 	} else if errors.IsNotFound(err) {
 		dep := &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
@@ -297,27 +296,22 @@ func NewControllerDeployment(van *types.VanRouterSpec, ownerRef metav1.OwnerRefe
 
 		created, err := deployments.Create(dep)
 		if err != nil {
-			fmt.Println("Failed to create controller deployment: ", err.Error())
-			return nil
+			return nil, fmt.Errorf("Failed to create controller deployment: %w", err)
 		} else {
-			return created
+			return created, nil
 		}
 
 	} else {
 		dep := &appsv1.Deployment{}
-		fmt.Println("Failed to check controller deployment: ", err.Error())
-		return dep
+		return dep, fmt.Errorf("Failed to check controller deployment: %w", err)
 	}
-
-	return nil
 }
 
-func NewTransportDeployment(van *types.VanRouterSpec, cli *kubernetes.Clientset) *appsv1.Deployment {
+func NewTransportDeployment(van *types.VanRouterSpec, cli *kubernetes.Clientset) (*appsv1.Deployment, error) {
 	deployments := cli.AppsV1().Deployments(van.Namespace)
 	existing, err := deployments.Get(types.TransportDeploymentName, metav1.GetOptions{})
 	if err == nil {
-		fmt.Println("VAN site transport already exists")
-		return existing
+		return existing, nil
 	} else if errors.IsNotFound(err) {
 		dep := &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
@@ -351,17 +345,13 @@ func NewTransportDeployment(van *types.VanRouterSpec, cli *kubernetes.Clientset)
 
 		created, err := deployments.Create(dep)
 		if err != nil {
-			fmt.Println("Failed to create transport deployment: ", err.Error())
-			return nil
+			return nil, fmt.Errorf("Failed to create transport deployment: %w", err)
 		} else {
-			return created
+			return created, nil
 		}
 
 	} else {
 		dep := &appsv1.Deployment{}
-		fmt.Println("Failed to check transport deployment: ", err.Error())
-		return dep
+		return dep, fmt.Errorf("Failed to check transport deployment: %w", err)
 	}
-
-	return nil
 }

--- a/pkg/kube/rolebindings.go
+++ b/pkg/kube/rolebindings.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ajssmith/skupper/api/types"
 )
 
-func NewRoleBindingWithOwner(rb types.RoleBinding, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) *rbacv1.RoleBinding {
+func NewRoleBindingWithOwner(rb types.RoleBinding, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) (*rbacv1.RoleBinding, error) {
 	name := rb.ServiceAccount + "-" + rb.Role
 	rolebinding := &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
@@ -36,11 +36,11 @@ func NewRoleBindingWithOwner(rb types.RoleBinding, owner metav1.OwnerReference, 
 	actual, err := kubeclient.RbacV1().RoleBindings(namespace).Create(rolebinding)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			fmt.Println("Role binding", name, "already exists")
+                        return nil, fmt.Errorf("Role binding %s already exists", name)
 		} else {
-			fmt.Println("Could not create role binding", name, ":", err)
+                        return nil, fmt.Errorf("Could not create role binding %s : %w", name, err)
 		}
 
 	}
-	return actual
+	return actual, nil
 }

--- a/pkg/kube/roles.go
+++ b/pkg/kube/roles.go
@@ -6,13 +6,12 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ajssmith/skupper/api/types"
 )
 
-func NewRoleWithOwner(newrole types.Role, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) *rbacv1.Role {
+func NewRoleWithOwner(newrole types.Role, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) (*rbacv1.Role, error) {
 	role := &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",
@@ -26,12 +25,7 @@ func NewRoleWithOwner(newrole types.Role, owner metav1.OwnerReference, namespace
 	}
 	actual, err := kubeclient.RbacV1().Roles(namespace).Create(role)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			fmt.Println("Role", newrole.Name, "already exists")
-		} else {
-			fmt.Println("Could not create role", newrole.Name, ":", err)
-		}
-
+                return nil, fmt.Errorf("Could not create role: %w", err)
 	}
-	return actual
+	return actual, nil
 }

--- a/pkg/kube/routes.go
+++ b/pkg/kube/routes.go
@@ -24,8 +24,7 @@ func NewRouteWithOwner(rte types.Route, owner metav1.OwnerReference, namespace s
 	}
 	current, err := rc.Routes(namespace).Get(rte.Name, metav1.GetOptions{})
 	if err == nil {
-		fmt.Println("Route", rte.Name, "already exists")
-		return current, nil
+		return current, fmt.Errorf("Route %s already exists", rte.Name)
 	} else if errors.IsNotFound(err) {
 		route := &routev1.Route{
 			TypeMeta: metav1.TypeMeta{
@@ -54,13 +53,11 @@ func NewRouteWithOwner(rte types.Route, owner metav1.OwnerReference, namespace s
 
 		created, err := rc.Routes(namespace).Create(route)
 		if err != nil {
-			fmt.Println("Failed to create route: ", err.Error())
-			return nil, err
+			return nil, fmt.Errorf("Failed to create route : %w", err)
 		} else {
 			return created, nil
 		}
 	} else {
-		fmt.Println("Failed while checking route: ", err.Error())
-		return nil, err
+		return nil, fmt.Errorf("Failed while checking route: %w", err)
 	}
 }

--- a/pkg/kube/secrets.go
+++ b/pkg/kube/secrets.go
@@ -13,33 +13,29 @@ import (
 	"github.com/ajssmith/skupper/pkg/utils/configs"
 )
 
-func NewCertAuthorityWithOwner(ca types.CertAuthority, owner metav1.OwnerReference, namespace string, cli *kubernetes.Clientset) *corev1.Secret {
+func NewCertAuthorityWithOwner(ca types.CertAuthority, owner metav1.OwnerReference, namespace string, cli *kubernetes.Clientset) (*corev1.Secret, error) {
 
 	existing, err := cli.CoreV1().Secrets(namespace).Get(ca.Name, metav1.GetOptions{})
 	if err == nil {
-		fmt.Println("CA", ca.Name, "already exists")
-		return existing
+		return existing, nil
 	} else if errors.IsNotFound(err) {
 		newca := certs.GenerateCASecret(ca.Name, ca.Name)
 		newca.ObjectMeta.OwnerReferences = []metav1.OwnerReference{owner}
 		_, err := cli.CoreV1().Secrets(namespace).Create(&newca)
 		if err == nil {
-			return &newca
+			return &newca, nil
 		} else {
-			fmt.Println("Failed to create CA", ca.Name, ": ", err.Error())
+                        return nil, fmt.Errorf("Failed to create CA %s : %w", ca.Name, err)
 		}
 	} else {
-		fmt.Println("Failed to check CA", ca.Name, ": ", err.Error())
+                return nil, fmt.Errorf("Failed to check CA %s : %w", ca.Name, err)
 	}
-	return nil
-
 }
 
 func NewSecretWithOwner(cred types.Credential, owner metav1.OwnerReference, namespace string, cli *kubernetes.Clientset) (*corev1.Secret, error) {
 	caSecret, err := cli.CoreV1().Secrets(namespace).Get(cred.CA, metav1.GetOptions{})
 	if err != nil {
-		fmt.Println("Failed to retrieve CA", err.Error())
-		return nil, err
+		return nil, fmt.Errorf("Failed to retrieve CA: %w", err)
 	}
 	secret := certs.GenerateSecret(cred.Name, cred.Subject, cred.Hosts, caSecret)
 	if cred.ConnectJson {
@@ -48,12 +44,7 @@ func NewSecretWithOwner(cred types.Credential, owner metav1.OwnerReference, name
 	secret.ObjectMeta.OwnerReferences = []metav1.OwnerReference{owner}
 	_, err = cli.CoreV1().Secrets(namespace).Create(&secret)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			fmt.Println("Secret already exists: ", cred.Name)
-		} else {
-			fmt.Println("Could not create secret: ", err.Error())
-		}
-		return nil, err
+                return nil, fmt.Errorf("Could not create secret: %w", err)
 	}
 
 	return &secret, nil
@@ -62,12 +53,9 @@ func NewSecretWithOwner(cred types.Credential, owner metav1.OwnerReference, name
 func DeleteSecret(name string, namespace string, cli *kubernetes.Clientset) error {
 	secrets := cli.CoreV1().Secrets(namespace)
 	err := secrets.Delete(name, &metav1.DeleteOptions{})
-	if err == nil {
-		fmt.Println("Secret", name, "deleted")
-	} else if errors.IsNotFound(err) {
-		fmt.Println("Secret", name, "does not exist")
-	} else {
-		fmt.Println("Failed to delete secret: ", err.Error())
-	}
-	return err
+
+	if err != nil {
+                return fmt.Errorf("Failed to delete secret: %w", err)
+        }
+        return nil
 }

--- a/pkg/kube/serviceaccounts.go
+++ b/pkg/kube/serviceaccounts.go
@@ -5,14 +5,13 @@ import (
 
 	//appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ajssmith/skupper/api/types"
 )
 
-func NewServiceAccountWithOwner(sa types.ServiceAccount, owner metav1.OwnerReference, namespace string, cli *kubernetes.Clientset) *corev1.ServiceAccount {
+func NewServiceAccountWithOwner(sa types.ServiceAccount, owner metav1.OwnerReference, namespace string, cli *kubernetes.Clientset) (*corev1.ServiceAccount, error) {
 	serviceaccount := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -26,12 +25,7 @@ func NewServiceAccountWithOwner(sa types.ServiceAccount, owner metav1.OwnerRefer
 	}
 	actual, err := cli.CoreV1().ServiceAccounts(namespace).Create(serviceaccount)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			fmt.Println("Service account", sa.ServiceAccount, "already exists")
-		} else {
-			fmt.Println("Could not create service account", sa.ServiceAccount, ":", err)
-		}
-
+                return nil, fmt.Errorf("Could not create service account: %w", err)
 	}
-	return actual
+	return actual, nil
 }

--- a/pkg/kube/services.go
+++ b/pkg/kube/services.go
@@ -110,7 +110,6 @@ func NewServiceForProxy(desiredService types.ServiceInterface, namespace string,
 func NewServiceWithOwner(svc types.Service, owner metav1.OwnerReference, namespace string, kubeclient *kubernetes.Clientset) (*corev1.Service, error) {
 	current, err := kubeclient.CoreV1().Services(namespace).Get(svc.Name, metav1.GetOptions{})
 	if err == nil {
-		fmt.Println("Service", svc.Name, "already exists")
 		return current, nil
 	} else if errors.IsNotFound(err) {
 		labels := getLabels("router", "")
@@ -131,13 +130,10 @@ func NewServiceWithOwner(svc types.Service, owner metav1.OwnerReference, namespa
 		}
 		created, err := kubeclient.CoreV1().Services(namespace).Create(service)
 		if err != nil {
-			fmt.Println("Failed to create service: ", err.Error())
-			return nil, err
+			return nil, fmt.Errorf("Failed to create service: %w", err)
 		} else {
 			return created, nil
 		}
-	} else {
-		fmt.Println("Failed while checking service: ", err.Error())
-		return nil, err
-	}
+	} 
+        return nil, fmt.Errorf("Failed while checking service: %w", err)
 }


### PR DESCRIPTION
Change all error print statements to error returns, using fmt.Errorf() with %w format verb to wrap lower level errors.

